### PR TITLE
Dependabot: update even composer.json, but only dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,5 @@ updates:
         directory: "/"
         schedule:
             interval: monthly
-        versioning-strategy: lockfile-only
+        allow:
+            dependency-type: development


### PR DESCRIPTION
- So that after dependabot update, we dont need to deal with old phpstan versions anymore