### PR TITLE
dependabot: fix dependency type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
         schedule:
             interval: monthly
         allow:
-            dependency-type: development
+            - dependency-type: development


### PR DESCRIPTION
- CI is green in MR even when dependabot config is invalid, see [issue](https://github.com/dependabot/dependabot-core/issues/4605)