### PR TITLE
dependabot: never update major version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
         allow:
             - dependency-type: development
         versioning-strategy: increase
+        ignore:
+            -
+                dependency-name: "*"
+                update-types: ["version-update:semver-major"] # never update major versions


### PR DESCRIPTION
- prevent things like https://github.com/shipmonk-rnd/doctrine-hint-driven-sql-walker/pull/9