### PR TITLE
Fix README example for query hints usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ composer require shipmonk/doctrine-hint-driven-sql-walker
 
 ```php
 $queryBuilder
+    ->getQuery()
     ->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, HintDrivenSqlWalker::class)
     ->setHint(MaxExecutionTimeHintHandler::class, 1000)
 ```


### PR DESCRIPTION
Hints should be set on the Query object, not the QueryBuilder. The example now correctly shows calling getQuery() before setHint().

Fixes #58