### PR TITLE
Bump phpunit/phpunit to fix CVE-2026-24765

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "phpstan/phpstan": "2.0.1",
         "phpstan/phpstan-phpunit": "2.0.0",
         "phpstan/phpstan-strict-rules": "2.0.0",
-        "phpunit/phpunit": "10.5.36",
+        "phpunit/phpunit": "^10.5.62",
         "shipmonk/coding-standard": "^0.2.0",
         "shipmonk/composer-dependency-analyser": "1.7.0",
         "shipmonk/phpstan-rules": "4.0.0",


### PR DESCRIPTION
## Summary
- Bumps `phpunit/phpunit` from `10.5.36` to `^10.5.62` to fix [CVE-2026-24765](https://github.com/advisories/GHSA-vvj3-c3rp-c85p) (unsafe deserialization in PHPT code coverage handling, CVSS 7.8 High)